### PR TITLE
Add a debugging flag to the workflow.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,12 +15,21 @@ inputs:
       indicating whether it is possible to fast forward the target
       branch.
     default: false
+  debug:
+    description: >
+      Enables debugging output.
+
+      If set to 1 or true, increases the workflow's verbosity.  This
+      may also execute some additional RPCs, and so should normally
+      be disabled.
+    default: 0
 runs:
   using: "composite"
   steps:
     # github.action_path is set to $REPO.
     - run: |
         export GITHUB_TOKEN=${{ inputs.github_token }}
+        export DEBUG=${{ inputs.debug }}
         if test "x${{ inputs.merge }}" = xtrue
         then
             ${{ github.action_path }}/src/fast-forward.sh --merge

--- a/src/fast-forward.sh
+++ b/src/fast-forward.sh
@@ -25,7 +25,14 @@
 set -e
 
 # Set to 1 to get some debugging information dumped to stderr.
-DEBUG=0
+case "${DEBUG:-0}" in
+    0 | false | FALSE) DEBUG=0;;
+    [0-9] | true | TRUE) DEBUG=1;;
+    *)
+        echo "Warning: Invalid value ('$DEBUG') for DEBUG." >&2;
+        DEBUG=1
+        ;;
+esac
 
 if test "x$GITHUB_EVENT_PATH" = x
 then


### PR DESCRIPTION
  - Add the `debug` input variable to allow the user to increase the workflow's debugging output.