### PR TITLE
Add an option to only post a comment on error.

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -19,4 +19,9 @@ jobs:
         uses: sequoia-pgp/fast-forward@main
         with:
           merge: true
+          # To reduce the workflow's verbosity, use 'on-error'
+          # to only post a comment when an error occurs, or 'never' to
+          # never post a comment.  (In all cases the information is
+          # still available in the step's summary.)
+          comment: always
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,3 +18,8 @@ jobs:
         uses: sequoia-pgp/fast-forward@main
         with:
           merge: false
+          # To reduce the workflow's verbosity, use 'on-error'
+          # to only post a comment when an error occurs, or 'never' to
+          # never post a comment.  (In all cases the information is
+          # still available in the step's summary.)
+          comment: always

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ jobs:
     steps:
       - name: Checking if fast forwarding is possible
         uses: sequoia-pgp/fast-forward@main
+        with:
+          merge: false
+          # To reduce the workflow's verbosity, use 'on-error'
+          # to only post a comment when an error occurs, or 'never' to
+          # never post a comment.  (In all cases the information is
+          # still available in the step's summary.)
+          comment: always
 ```
 
 ## Fast Forwarding a Pull Request
@@ -115,7 +122,12 @@ jobs:
       - name: Fast forwarding
         uses: sequoia-pgp/fast-forward@main
         with:
-            merge: true
+          merge: true
+          # To reduce the workflow's verbosity, use 'on-error'
+          # to only post a comment when an error occurs, or 'never' to
+          # never post a comment.  (In all cases the information is
+          # still available in the step's summary.)
+          comment: always
 ```
 
 This workflow is only run when a comment that includes `/fast-forward`

--- a/action.yml
+++ b/action.yml
@@ -19,14 +19,18 @@ inputs:
     description: >
       Whether to post a comment.
 
-      If set to true, this posts a comment to the pull request
-      indicating whether it is possible to fast-forward the target
-      branch, and, if merge is true, whether fast forwarding
+      If set to true or always, this posts a comment to the pull
+      request indicating whether it is possible to fast-forward the
+      target branch, and, if merge is true, whether fast forwarding
       succeeded.
 
-      If false, the comment is still available via the comment output
-      variable.
-    default: true
+      If set to on-error (the default), a comment is only posted if
+      an error occurs.
+
+      If false or never, no comment is posted.  The comment is
+      still available via the comment output variable, and in the
+      step's summary.
+    default: on-error
   debug:
     description: >
       Enables debugging output.


### PR DESCRIPTION
  - To reduce the amount of chit chat, add an option to only post a comment on error.

  - Make this the default.