### PR TITLE
Add `--globoff` to `curl` commands

### DIFF
--- a/src/fast-forward.sh
+++ b/src/fast-forward.sh
@@ -115,7 +115,7 @@ function github_pull_request {
                 exit 1
             fi
 
-            curl --silent --show-error --location \
+            curl --silent --show-error --location --globoff \
                  -X GET \
                  -H "Accept: application/vnd.github+json" \
                  -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -278,7 +278,7 @@ LOG=$(mktemp)
         COLLABORATORS_URL="${COLLABORATORS_URL%\{/collaborator\}}"
 
         PERM=$(mktemp)
-        curl --silent --show-error -o "$PERM" --location \
+        curl --silent --show-error -o "$PERM" --location --globoff \
              -H "Accept: application/vnd.github+json" \
              -H "Authorization: Bearer $GITHUB_TOKEN" \
              -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -334,7 +334,7 @@ then
     if test "x$COMMENTS_URL" != x
     then
         echo "Posting comment to $COMMENTS_URL."
-        curl --silent --show-error --location \
+        curl --silent --show-error --location --globoff \
              -X POST \
              -H "Accept: application/vnd.github+json" \
              -H "Authorization: Bearer $GITHUB_TOKEN" \


### PR DESCRIPTION
`curl` defaults to treating certain characters in the URL, including brackets, as being glob characters, expanding to ranges of URLs. This causes problems if e.g. the username we're checking permissions for is `something[bot]`. Adding `--globoff` disables that behavior and makes `curl` just encode the brackets as part of the URL.