### PR TITLE
Update comment.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 #   - Resource owner: sequoia-pgp
 #   - Only select repositories - sequoia-pgp/fast-forward-unit-tests
 #   - Permissions - select read and write permission for contents, issues,
-#     and pull requests.
+#     pull requests, and workflows.
 #
 # Add the secret to the fast-forward repository by going to:
 #


### PR DESCRIPTION
The personal access token needed to run the CI workflow now also needs to have read and write permission for `workflows`.  Update the comment.