### PR TITLE
Use `git push --dry-run` to check push permissions

### DIFF
--- a/src/fast-forward.sh
+++ b/src/fast-forward.sh
@@ -273,18 +273,7 @@ LOG=$(mktemp)
         # Check that the user is allowed and then fast forward the
         # target!
 
-        # https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user
-        COLLABORATORS_URL="$(github_event .repository.collaborators_url)"
-        COLLABORATORS_URL="${COLLABORATORS_URL%\{/collaborator\}}"
-
-        PERM=$(mktemp)
-        curl --silent --show-error -o "$PERM" --location --globoff \
-             -H "Accept: application/vnd.github+json" \
-             -H "Authorization: Bearer $GITHUB_TOKEN" \
-             -H "X-GitHub-Api-Version: 2022-11-28" \
-             $COLLABORATORS_URL/$(github_event .sender.login)/permission
-
-        if test "x$(jq -r .user.permissions.push < $PERM)" = xtrue
+        if git push origin --dry-run "$PR_SHA:$BASE_REF" 2>/dev/null
         then
             echo -n "Fast forwarding \`$BASE_REF\` ($BASE_SHA) to"
             echo " \`$PR_REF\` ($PR_SHA)."


### PR DESCRIPTION
The action doesn't play nice with GitHub Apps:
1. If the action is triggered by a GitHub App (a bot user), the curl call fails 
Because the bot username includes `[bot]` suffix, the following line is not quoted: https://github.com/sequoia-pgp/fast-forward/blob/e2c6fb52f977408912b000ad4577a669f1c4f5fe/src/fast-forward.sh#L285

```
curl: (3) bad range in URL position 85:
https://api.github.com/repos/<redacted>/<redacted>/collaborators/<redacted>[bot]/permission
```

2. `/repos/{owner}/{repo}/collaborators/{username}/permission` for a token provisined by GitHub App

```yaml
      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
        id: github-app
        with:
          app-id: ${{ vars.APP_ID }}
          private-key: ${{ secrets.APP_PRIVATE_KEY }}
          permission-contents: write
          permission-pull-requests: write
          permission-workflows: write
```

Return something like this:

```json
{
    "permission": "none",
    "user": {
      ...
      "type": "Bot",
      "user_view_type": "public",
      "site_admin": false,
      "permissions": {
        "admin": false,
        "maintain": false,
        "push": false,
        "triage": false,
        "pull": false
      },
      "role_name": ""
    },
    "role_name": ""
  }
``` 
So the condition below evaluated to false, even though the token has push access
https://github.com/sequoia-pgp/fast-forward/blob/e2c6fb52f977408912b000ad4577a669f1c4f5fe/src/fast-forward.sh#L287

To fix both issues, I propose switching the check with `git push --dry-run` which, according to [the manpage](https://git-scm.com/docs/git-push#Documentation/git-push.txt---dry-run) does everything except actually sending the updates.